### PR TITLE
fix: do not apply margin when error message is empty

### DIFF
--- a/mixins/required-field.html
+++ b/mixins/required-field.html
@@ -32,7 +32,13 @@
         font-size: .75em;
         line-height: 1;
         color: var(--material-error-text-color);
-        margin-top: 6px;
+      }
+
+      /* Margin that doesn’t reserve space when there’s no error message */
+      [part="error-message"]:not(:empty)::before {
+        content: "";
+        display: block;
+        height: 6px;
       }
 
       :host(:not([invalid])) [part="error-message"] {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-material-styles/84)
<!-- Reviewable:end -->
