### PR TITLE
Add a test to ensure styles aren't duplicated

### DIFF
--- a/version.html
+++ b/version.html
@@ -11,7 +11,9 @@
       }
     }
 
-    customElements.define('vaadin-material-styles', Material);
+    if (!customElements.get('vaadin-material-styles')) {
+      customElements.define('vaadin-material-styles', Material);
+    }
 
     window.Vaadin.Material = Material;
   })();


### PR DESCRIPTION
We have a polymer 3 app that has been having some issues.

In certain circumstances on an unusual setup (it includes dynamic DOM injection) you might have a situation that leads to the following: 
Failed to execute 'define' on 'CustomElementRegistry': this name has already been used with this registry

Only vaadin material elements have this issue: Polymer elements seem to be immune.
This test will ensure that duplicates don't happen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-material-styles/88)
<!-- Reviewable:end -->
