### PR TITLE
fix: blank page and JS errors in IE11

### DIFF
--- a/color.html
+++ b/color.html
@@ -5,7 +5,8 @@
 <dom-module id="material-color-light">
   <template>
     <style>
-      :host {
+      :host,
+      #host-fix {
         /* Text colors */
         --material-body-text-color: var(--light-theme-text-color, rgba(0, 0, 0, 0.87));
         --material-secondary-text-color: var(--light-theme-secondary-color, rgba(0, 0, 0, 0.54));
@@ -105,7 +106,8 @@
 <dom-module id="material-color-dark">
   <template>
     <style>
-      :host {
+      :host,
+      #host-fix {
         /* Text colors */
         --material-body-text-color: var(--dark-theme-text-color, rgba(255, 255, 255, 1));
         --material-secondary-text-color: var(--dark-theme-secondary-color, rgba(255, 255, 255, 0.7));


### PR DESCRIPTION
Fixes #85

In cases where :host selector is used alone for a CSS block in document level styles (e.g. <custom-style>), the block will be broken in at least polyfilled browsers like Edge and IE11 which may break also the following CSS block. In IE11 this seems to also cause some JS errors (seemingly coming from the polyfills) which might stop the whole page from working and only render a blank page. This isn't a problem if the block contains other valid selectors separated with a comma (in that case only the invalid :host selector is automatically removed from document level styles).

This is an issue in cases where we have some style modules which may be used both in shadow DOM and in global scope (via custom-style).

Workaround the issue by adding a valid dummy selector "#host-fix-ie11" to style blocks which might be used in this way and only had the ":host" selector.

Needs to be backported to 1.x branch for Vaadin 13.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-material-styles/89)
<!-- Reviewable:end -->
