### PR TITLE
fix: Roboto font not loaded in the demo on Edge and IE11

### DIFF
--- a/typography.html
+++ b/typography.html
@@ -3,7 +3,7 @@
 <link rel="import" href="../polymer/lib/elements/dom-module.html">
 
 <!-- Import Roboto from Google Fonts -->
-<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" crossorigin="anonymous">
+<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" crossorigin="anonymous">
 
 <custom-style>
   <style>


### PR DESCRIPTION
Fixes #58

This doesn't affect `master`, only needed for `1.x` branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-material-styles/90)
<!-- Reviewable:end -->
