### PR TITLE
feat: expose style modules as css literals

### DIFF
--- a/all-imports.d.ts
+++ b/all-imports.d.ts
@@ -1,0 +1,7 @@
+export * from './mixins/field-button.js';
+export * from './mixins/menu-overlay.js';
+export * from './mixins/overlay.js';
+export * from './mixins/required-field.js';
+export * from './color.js';
+export * from './shadow.js';
+export * from './typography.js';

--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,8 @@
     "wct.conf.js"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^v2.0.0"
+    "polymer": "Polymer/polymer#^v2.0.0",
+    "vaadin-themable-mixin": "^1.6.1"
   },
   "devDependencies": {
     "web-component-tester": "^6.0.0",

--- a/color.d.ts
+++ b/color.d.ts
@@ -1,0 +1,7 @@
+import {CSSResult} from 'lit-element';
+
+export const colorLight: CSSResult;
+
+export const colorDark: CSSResult;
+
+export const colorBase: CSSResult;

--- a/color.html
+++ b/color.html
@@ -130,24 +130,8 @@ MAGI ADD END -->
 Vaadin.registerStyles('', colorLight, {moduleId: 'material-color-light'});
 
 Vaadin.MaterialStyles.colorLight = colorLight;
-})();
-</script>
-MAGI ADD END -->
 
-<!-- MAGI ADD START
-<script>
-  /**
-   * @namespace Vaadin
-   */
-  window.Vaadin = window.Vaadin || {};
-
-  /**
-   * @namespace Vaadin.MaterialStyles
-   */
-  window.Vaadin.MaterialStyles = window.Vaadin.MaterialStyles || {};
-
-  (function() {
-    const colorDark = Vaadin.css`
+const colorDark = Vaadin.css`
 MAGI ADD END -->
 
 <!-- MAGI REMOVE START -->
@@ -210,24 +194,8 @@ MAGI ADD END -->
 Vaadin.registerStyles('', colorDark, {moduleId: 'material-color-dark'});
 
 Vaadin.MaterialStyles.colorDark = colorDark;
-})();
-</script>
-MAGI ADD END -->
 
-<!-- MAGI ADD START
-<script>
-  /**
-   * @namespace Vaadin
-   */
-  window.Vaadin = window.Vaadin || {};
-
-  /**
-   * @namespace Vaadin.MaterialStyles
-   */
-  window.Vaadin.MaterialStyles = window.Vaadin.MaterialStyles || {};
-
-  (function() {
-    const colorBase = Vaadin.css`
+const colorBase = Vaadin.css`
 MAGI ADD END -->
 <!-- MAGI REMOVE START -->
 <custom-style>

--- a/color.html
+++ b/color.html
@@ -1,10 +1,31 @@
 <link rel="import" href="version.html">
 <link rel="import" href="../polymer/lib/elements/custom-style.html">
+<!-- MAGI REMOVE START -->
 <link rel="import" href="../polymer/lib/elements/dom-module.html">
+<!-- MAGI REMOVE END -->
 
+<!-- MAGI ADD START
+<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.MaterialStyles
+   */
+  window.Vaadin.MaterialStyles = window.Vaadin.MaterialStyles || {};
+
+  (function() {
+    const colorLight = Vaadin.css`
+MAGI ADD END -->
+
+<!-- MAGI REMOVE START -->
 <dom-module id="material-color-light">
   <template>
     <style>
+      /* MAGI REMOVE END */
       :host,
       #host-fix {
         /* Text colors */
@@ -99,13 +120,41 @@
       a {
         color: inherit;
       }
+      /* MAGI REMOVE START */
     </style>
   </template>
 </dom-module>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+Vaadin.registerStyles('', colorLight, {moduleId: 'material-color-light'});
 
+Vaadin.MaterialStyles.colorLight = colorLight;
+})();
+</script>
+MAGI ADD END -->
+
+<!-- MAGI ADD START
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.MaterialStyles
+   */
+  window.Vaadin.MaterialStyles = window.Vaadin.MaterialStyles || {};
+
+  (function() {
+    const colorDark = Vaadin.css`
+MAGI ADD END -->
+
+<!-- MAGI REMOVE START -->
 <dom-module id="material-color-dark">
   <template>
     <style>
+      /* MAGI REMOVE END */
       :host,
       #host-fix {
         /* Text colors */
@@ -151,13 +200,43 @@
         background-color: var(--material-background-color);
         color: var(--material-body-text-color);
       }
+      /* MAGI REMOVE START */
     </style>
   </template>
 </dom-module>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+Vaadin.registerStyles('', colorDark, {moduleId: 'material-color-dark'});
 
+Vaadin.MaterialStyles.colorDark = colorDark;
+})();
+</script>
+MAGI ADD END -->
+
+<!-- MAGI ADD START
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.MaterialStyles
+   */
+  window.Vaadin.MaterialStyles = window.Vaadin.MaterialStyles || {};
+
+  (function() {
+    const colorBase = Vaadin.css`
+MAGI ADD END -->
+<!-- MAGI REMOVE START -->
 <custom-style>
   <style>
     :root {
+    /* MAGI REMOVE END */
+    /* MAGI ADD START
+    :host {
+      MAGI ADD END */
       /* Text colors */
       --material-body-text-color: var(--light-theme-text-color, rgba(0, 0, 0, 0.87));
       --material-secondary-text-color: var(--light-theme-secondary-color, rgba(0, 0, 0, 0.54));
@@ -180,5 +259,17 @@
       /* Divider colors */
       --material-divider-color: rgba(0, 0, 0, 0.12);
     }
+    /* MAGI REMOVE START */
   </style>
 </custom-style>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+const $tpl = document.createElement('template');
+$tpl.innerHTML = `<custom-style><style>${colorBase.toString().replace(':host', 'html')}</style></custom-style>`;
+document.head.appendChild($tpl.content);
+
+Vaadin.MaterialStyles.colorBase = colorBase;
+})();
+</script>
+MAGI ADD END -->

--- a/color.html
+++ b/color.html
@@ -126,12 +126,12 @@ MAGI ADD END -->
 </dom-module>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-Vaadin.registerStyles('', colorLight, {moduleId: 'material-color-light'});
+    `;
+    Vaadin.registerStyles('', colorLight, {moduleId: 'material-color-light'});
 
-Vaadin.MaterialStyles.colorLight = colorLight;
+    Vaadin.MaterialStyles.colorLight = colorLight;
 
-const colorDark = Vaadin.css`
+    const colorDark = Vaadin.css`
 MAGI ADD END -->
 
 <!-- MAGI REMOVE START -->
@@ -190,12 +190,12 @@ MAGI ADD END -->
 </dom-module>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-Vaadin.registerStyles('', colorDark, {moduleId: 'material-color-dark'});
+    `;
+    Vaadin.registerStyles('', colorDark, {moduleId: 'material-color-dark'});
 
-Vaadin.MaterialStyles.colorDark = colorDark;
+    Vaadin.MaterialStyles.colorDark = colorDark;
 
-const colorBase = Vaadin.css`
+    const colorBase = Vaadin.css`
 MAGI ADD END -->
 <!-- MAGI REMOVE START -->
 <custom-style>
@@ -232,12 +232,12 @@ MAGI ADD END -->
 </custom-style>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-const $tpl = document.createElement('template');
-$tpl.innerHTML = `<custom-style><style>${colorBase.toString().replace(':host', 'html')}</style></custom-style>`;
-document.head.appendChild($tpl.content);
+    `;
+    const $tpl = document.createElement('template');
+    $tpl.innerHTML = `<custom-style><style>${colorBase.toString().replace(':host', 'html')}</style></custom-style>`;
+    document.head.appendChild($tpl.content);
 
-Vaadin.MaterialStyles.colorBase = colorBase;
-})();
+    Vaadin.MaterialStyles.colorBase = colorBase;
+  })();
 </script>
 MAGI ADD END -->

--- a/color.html
+++ b/color.html
@@ -20,7 +20,6 @@
   (function() {
     const colorLight = Vaadin.css`
 MAGI ADD END -->
-
 <!-- MAGI REMOVE START -->
 <dom-module id="material-color-light">
   <template>
@@ -133,7 +132,6 @@ MAGI ADD END -->
 
     const colorDark = Vaadin.css`
 MAGI ADD END -->
-
 <!-- MAGI REMOVE START -->
 <dom-module id="material-color-dark">
   <template>

--- a/magi-p3-post.js
+++ b/magi-p3-post.js
@@ -1,0 +1,11 @@
+module.exports = {
+  files: [
+    'all-imports.js'
+  ],
+  from: [
+    /import '\.\/(.+)\.js';/g
+  ],
+  to: [
+    `import './$1.js';\nexport * from './$1.js';`
+  ]
+};

--- a/mixins/field-button.d.ts
+++ b/mixins/field-button.d.ts
@@ -1,0 +1,3 @@
+import {CSSResult} from 'lit-element';
+
+export const fieldButton: CSSResult;

--- a/mixins/field-button.html
+++ b/mixins/field-button.html
@@ -59,10 +59,10 @@ MAGI ADD END -->
 </dom-module>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-Vaadin.registerStyles('', fieldButton, {moduleId: 'material-field-button'});
+    `;
+    Vaadin.registerStyles('', fieldButton, {moduleId: 'material-field-button'});
 
-Vaadin.MaterialStyles.fieldButton = fieldButton;
-})();
+    Vaadin.MaterialStyles.fieldButton = fieldButton;
+  })();
 </script>
 MAGI ADD END -->

--- a/mixins/field-button.html
+++ b/mixins/field-button.html
@@ -1,9 +1,27 @@
 <link rel="import" href="../font-icons.html">
 
+<!-- MAGI ADD START
+<link rel="import" href="../../vaadin-themable-mixin/register-styles.html">
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.MaterialStyles
+   */
+  window.Vaadin.MaterialStyles = window.Vaadin.MaterialStyles || {};
+
+  (function() {
+    const fieldButton = Vaadin.css`
+MAGI ADD END -->
+<!-- MAGI REMOVE START -->
 <dom-module id="material-field-button">
   <template>
     <style>
       /* TODO(platosha): align icon sizes with other elements */
+      /* MAGI REMOVE END */
       [part$="button"] {
         flex: none;
         width: 24px;
@@ -35,6 +53,16 @@
       [part$="button"]::before {
         font-family: "material-icons";
       }
+      /* MAGI REMOVE START */
     </style>
   </template>
 </dom-module>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+Vaadin.registerStyles('', fieldButton, {moduleId: 'material-field-button'});
+
+Vaadin.MaterialStyles.fieldButton = fieldButton;
+})();
+</script>
+MAGI ADD END -->

--- a/mixins/menu-overlay.d.ts
+++ b/mixins/menu-overlay.d.ts
@@ -1,0 +1,3 @@
+import {CSSResult} from 'lit-element';
+
+export const menuOverlay: CSSResult;

--- a/mixins/menu-overlay.html
+++ b/mixins/menu-overlay.html
@@ -26,10 +26,10 @@ MAGI ADD END -->
 </dom-module>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-Vaadin.registerStyles('', menuOverlay, {moduleId: 'material-menu-overlay', include: ['material-overlay']});
+    `;
+    Vaadin.registerStyles('', menuOverlay, {moduleId: 'material-menu-overlay', include: ['material-overlay']});
 
-Vaadin.MaterialStyles.menuOverlay = menuOverlay;
-})();
+    Vaadin.MaterialStyles.menuOverlay = menuOverlay;
+  })();
 </script>
 MAGI ADD END -->

--- a/mixins/menu-overlay.html
+++ b/mixins/menu-overlay.html
@@ -1,9 +1,35 @@
 <link rel="import" href="../color.html">
 <link rel="import" href="overlay.html">
 
+<!-- MAGI ADD START
+<link rel="import" href="../../vaadin-themable-mixin/register-styles.html">
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.MaterialStyles
+   */
+  window.Vaadin.MaterialStyles = window.Vaadin.MaterialStyles || {};
+
+  (function() {
+    const menuOverlay = Vaadin.css`
+MAGI ADD END -->
+<!-- MAGI REMOVE START -->
 <dom-module id="material-menu-overlay">
   <template>
     <style include="material-overlay">
     </style>
   </template>
 </dom-module>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+Vaadin.registerStyles('', menuOverlay, {moduleId: 'material-menu-overlay', include: ['material-overlay']});
+
+Vaadin.MaterialStyles.menuOverlay = menuOverlay;
+})();
+</script>
+MAGI ADD END -->

--- a/mixins/overlay.d.ts
+++ b/mixins/overlay.d.ts
@@ -1,0 +1,3 @@
+import {CSSResult} from 'lit-element';
+
+export const overlay: CSSResult;

--- a/mixins/overlay.html
+++ b/mixins/overlay.html
@@ -62,10 +62,10 @@ MAGI ADD END -->
 </dom-module>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-Vaadin.registerStyles('', overlay, {moduleId: 'material-overlay'});
+    `;
+    Vaadin.registerStyles('', overlay, {moduleId: 'material-overlay'});
 
-Vaadin.MaterialStyles.overlay = overlay;
-})();
+    Vaadin.MaterialStyles.overlay = overlay;
+  })();
 </script>
 MAGI ADD END -->

--- a/mixins/overlay.html
+++ b/mixins/overlay.html
@@ -2,9 +2,27 @@
 <link rel="import" href="../typography.html">
 <link rel="import" href="../shadow.html">
 
+<!-- MAGI ADD START
+<link rel="import" href="../../vaadin-themable-mixin/register-styles.html">
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.MaterialStyles
+   */
+  window.Vaadin.MaterialStyles = window.Vaadin.MaterialStyles || {};
+
+  (function() {
+    const overlay = Vaadin.css`
+MAGI ADD END -->
+<!-- MAGI REMOVE START -->
 <dom-module id="material-overlay">
   <template>
     <style>
+      /* MAGI REMOVE END */
       :host {
         top: 16px;
         right: 16px;
@@ -38,6 +56,16 @@
           opacity: 0;
         }
       }
+      /* MAGI REMOVE START */
     </style>
   </template>
 </dom-module>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+Vaadin.registerStyles('', overlay, {moduleId: 'material-overlay'});
+
+Vaadin.MaterialStyles.overlay = overlay;
+})();
+</script>
+MAGI ADD END -->

--- a/mixins/required-field.d.ts
+++ b/mixins/required-field.d.ts
@@ -1,0 +1,3 @@
+import {CSSResult} from 'lit-element';
+
+export const requiredField: CSSResult;

--- a/mixins/required-field.html
+++ b/mixins/required-field.html
@@ -1,8 +1,26 @@
 <link rel="import" href="../color.html">
 
+<!-- MAGI ADD START
+<link rel="import" href="../../vaadin-themable-mixin/register-styles.html">
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.MaterialStyles
+   */
+  window.Vaadin.MaterialStyles = window.Vaadin.MaterialStyles || {};
+
+  (function() {
+    const requiredField = Vaadin.css`
+MAGI ADD END -->
+<!-- MAGI REMOVE START -->
 <dom-module id="material-required-field">
   <template>
     <style>
+      /* MAGI REMOVE END */
       [part="label"] {
         display: block;
         position: absolute;
@@ -58,10 +76,19 @@
       }
 
       /* RTL specific styles */
-
       :host([dir="rtl"]) [part="label"] {
         transform-origin: 100% 75%;
       }
+      /* MAGI REMOVE START */
     </style>
   </template>
 </dom-module>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+Vaadin.registerStyles('', requiredField, {moduleId: 'material-required-field'});
+
+Vaadin.MaterialStyles.requiredField = requiredField;
+})();
+</script>
+MAGI ADD END -->

--- a/mixins/required-field.html
+++ b/mixins/required-field.html
@@ -85,10 +85,10 @@ MAGI ADD END -->
 </dom-module>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-Vaadin.registerStyles('', requiredField, {moduleId: 'material-required-field'});
+    `;
+    Vaadin.registerStyles('', requiredField, {moduleId: 'material-required-field'});
 
-Vaadin.MaterialStyles.requiredField = requiredField;
-})();
+    Vaadin.MaterialStyles.requiredField = requiredField;
+  })();
 </script>
 MAGI ADD END -->

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "homepage": "https://vaadin.com/themes",
   "files": [
     "*.js",
+    "*.d.ts",
     "mixins/*.js",
+    "mixins/*.d.ts",
     "!wdio.conf.js"
   ],
   "scripts": {

--- a/shadow.d.ts
+++ b/shadow.d.ts
@@ -1,0 +1,3 @@
+import {CSSResult} from 'lit-element';
+
+export const shadow: CSSResult;

--- a/shadow.html
+++ b/shadow.html
@@ -40,12 +40,12 @@ MAGI ADD END -->
 </custom-style>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-const $tpl = document.createElement('template');
-$tpl.innerHTML = `<custom-style><style>${shadow.toString().replace(':host', 'html')}</style></custom-style>`;
-document.head.appendChild($tpl.content);
+    `;
+    const $tpl = document.createElement('template');
+    $tpl.innerHTML = `<custom-style><style>${shadow.toString().replace(':host', 'html')}</style></custom-style>`;
+    document.head.appendChild($tpl.content);
 
-Vaadin.MaterialStyles.shadow = shadow;
-})();
+    Vaadin.MaterialStyles.shadow = shadow;
+  })();
 </script>
 MAGI ADD END -->

--- a/shadow.html
+++ b/shadow.html
@@ -1,9 +1,30 @@
 <link rel="import" href="version.html">
 <link rel="import" href="../polymer/lib/elements/custom-style.html">
 
+<!-- MAGI ADD START
+<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.MaterialStyles
+   */
+  window.Vaadin.MaterialStyles = window.Vaadin.MaterialStyles || {};
+
+  (function() {
+    const shadow = Vaadin.css`
+MAGI ADD END -->
+<!-- MAGI REMOVE START -->
 <custom-style>
-  <style is="custom-style">
+  <style>
     html {
+    /* MAGI REMOVE END */
+    /* MAGI ADD START
+    :host {
+      MAGI ADD END */
       /* from http://codepen.io/shyndman/pen/c5394ddf2e8b2a5c9185904b57421cdb */
       --material-shadow-elevation-2dp: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2);
       --material-shadow-elevation-3dp: 0 3px 4px 0 rgba(0, 0, 0, 0.14), 0 1px 8px 0 rgba(0, 0, 0, 0.12), 0 3px 3px -2px rgba(0, 0, 0, 0.4);
@@ -14,5 +35,17 @@
       --material-shadow-elevation-16dp: 0 16px 24px 2px rgba(0, 0, 0, 0.14), 0 6px 30px 5px rgba(0, 0, 0, 0.12), 0 8px 10px -5px rgba(0, 0, 0, 0.4);
       --material-shadow-elevation-24dp: 0 24px 38px 3px rgba(0, 0, 0, 0.14), 0 9px 46px 8px rgba(0, 0, 0, 0.12), 0 11px 15px -7px rgba(0, 0, 0, 0.4);
     }
+    /* MAGI REMOVE START */
   </style>
 </custom-style>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+const $tpl = document.createElement('template');
+$tpl.innerHTML = `<custom-style><style>${shadow.toString().replace(':host', 'html')}</style></custom-style>`;
+document.head.appendChild($tpl.content);
+
+Vaadin.MaterialStyles.shadow = shadow;
+})();
+</script>
+MAGI ADD END -->

--- a/typography.d.ts
+++ b/typography.d.ts
@@ -1,0 +1,5 @@
+import {CSSResult} from 'lit-element';
+
+export const font: CSSResult;
+
+export const typography: CSSResult;

--- a/typography.html
+++ b/typography.html
@@ -57,24 +57,8 @@ $tpl.innerHTML = `<custom-style><style>${font.toString().replace(':host', 'html'
 document.head.appendChild($tpl.content);
 
 Vaadin.MaterialStyles.font = font;
-})();
-</script>
-MAGI ADD END -->
 
-<!-- MAGI ADD START
-<script>
-  /**
-   * @namespace Vaadin
-   */
-  window.Vaadin = window.Vaadin || {};
-
-  /**
-   * @namespace Vaadin.MaterialStyles
-   */
-  window.Vaadin.MaterialStyles = window.Vaadin.MaterialStyles || {};
-
-  (function() {
-    const typography = Vaadin.css`
+const typography = Vaadin.css`
 MAGI ADD END -->
 
 <!-- MAGI REMOVE START -->

--- a/typography.html
+++ b/typography.html
@@ -51,14 +51,14 @@ MAGI ADD END -->
 </custom-style>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-const $tpl = document.createElement('template');
-$tpl.innerHTML = `<custom-style><style>${font.toString().replace(':host', 'html')}</style></custom-style>`;
-document.head.appendChild($tpl.content);
+    `;
+    const $tpl = document.createElement('template');
+    $tpl.innerHTML = `<custom-style><style>${font.toString().replace(':host', 'html')}</style></custom-style>`;
+    document.head.appendChild($tpl.content);
 
-Vaadin.MaterialStyles.font = font;
+    Vaadin.MaterialStyles.font = font;
 
-const typography = Vaadin.css`
+    const typography = Vaadin.css`
 MAGI ADD END -->
 
 <!-- MAGI REMOVE START -->
@@ -153,11 +153,11 @@ MAGI ADD END -->
 </dom-module>
 <!-- MAGI REMOVE END -->
 <!-- MAGI ADD START
-`;
-Vaadin.registerStyles('', typography, {moduleId: 'material-typography'});
+    `;
+    Vaadin.registerStyles('', typography, {moduleId: 'material-typography'});
 
-Vaadin.MaterialStyles.typography = typography;
-})();
+    Vaadin.MaterialStyles.typography = typography;
+  })();
 </script>
 MAGI ADD END -->
 

--- a/typography.html
+++ b/typography.html
@@ -178,6 +178,4 @@ Vaadin.MaterialStyles.typography = typography;
 MAGI ADD END -->
 
 <!-- Import Roboto from Google Fonts -->
-<!-- MAGI REMOVE START -->
 <script src="./font-roboto.js"></script>
-<!-- MAGI REMOVE END -->

--- a/typography.html
+++ b/typography.html
@@ -60,7 +60,6 @@ MAGI ADD END -->
 
     const typography = Vaadin.css`
 MAGI ADD END -->
-
 <!-- MAGI REMOVE START -->
 <dom-module id="material-typography">
   <template>

--- a/typography.html
+++ b/typography.html
@@ -1,10 +1,33 @@
 <link rel="import" href="version.html">
 <link rel="import" href="../polymer/lib/elements/custom-style.html">
+<!-- MAGI REMOVE START -->
 <link rel="import" href="../polymer/lib/elements/dom-module.html">
+<!-- MAGI REMOVE END -->
 
+<!-- MAGI ADD START
+<link rel="import" href="../vaadin-themable-mixin/register-styles.html">
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.MaterialStyles
+   */
+  window.Vaadin.MaterialStyles = window.Vaadin.MaterialStyles || {};
+
+  (function() {
+    const font = Vaadin.css`
+MAGI ADD END -->
+<!-- MAGI REMOVE START -->
 <custom-style>
   <style>
     html {
+    /* MAGI REMOVE END */
+    /* MAGI ADD START
+    :host {
+      MAGI ADD END */
       /* Font family */
       --material-font-family: 'Roboto', sans-serif;
 
@@ -23,13 +46,53 @@
       /* Icon size */
       --material-icon-font-size: 20px;
     }
+    /* MAGI REMOVE START */
   </style>
 </custom-style>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+const $tpl = document.createElement('template');
+$tpl.innerHTML = `<custom-style><style>${font.toString().replace(':host', 'html')}</style></custom-style>`;
+document.head.appendChild($tpl.content);
 
+Vaadin.MaterialStyles.font = font;
+})();
+</script>
+MAGI ADD END -->
+
+<!-- MAGI ADD START
+<script>
+  /**
+   * @namespace Vaadin
+   */
+  window.Vaadin = window.Vaadin || {};
+
+  /**
+   * @namespace Vaadin.MaterialStyles
+   */
+  window.Vaadin.MaterialStyles = window.Vaadin.MaterialStyles || {};
+
+  (function() {
+    const typography = Vaadin.css`
+MAGI ADD END -->
+
+<!-- MAGI REMOVE START -->
 <dom-module id="material-typography">
   <template>
     <style>
+      /* MAGI REMOVE END */
       body {
+        font-family: var(--material-font-family);
+        font-size: var(--material-body-font-size);
+        line-height: 1.4;
+        -webkit-text-size-adjust: 100%;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+      }
+
+      /* Can’t combine with the above selector because that doesn’t work in browsers without native shadow dom */
+      :host {
         font-family: var(--material-font-family);
         font-size: var(--material-body-font-size);
         line-height: 1.4;
@@ -100,9 +163,19 @@
       strong {
         font-weight: 500;
       }
+      /* MAGI REMOVE START */
     </style>
   </template>
 </dom-module>
+<!-- MAGI REMOVE END -->
+<!-- MAGI ADD START
+`;
+Vaadin.registerStyles('', typography, {moduleId: 'material-typography'});
+
+Vaadin.MaterialStyles.typography = typography;
+})();
+</script>
+MAGI ADD END -->
 
 <!-- Import Roboto from Google Fonts -->
 <!-- MAGI REMOVE START -->


### PR DESCRIPTION
Fixes #100 

Depends on #98 
Depends on #101 


<details>
<summary>color.js</summary>

```js
import './version.js';
import '@polymer/polymer/lib/elements/custom-style.js';
import { css, registerStyles } from 'vaadin-themable-mixin/register-styles.js';
const colorLight = css`

  :host,
  #host-fix {
    /* Text colors */
    --material-body-text-color: var(--light-theme-text-color, rgba(0, 0, 0, 0.87));
    --material-secondary-text-color: var(--light-theme-secondary-color, rgba(0, 0, 0, 0.54));
    --material-disabled-text-color: var(--light-theme-disabled-color, rgba(0, 0, 0, 0.38));

    /* Primary colors */
    --material-primary-color: var(--primary-color, #6200ee);
    --material-primary-contrast-color: var(--dark-theme-base-color, #fff);
    --material-primary-text-color: var(--material-primary-color);

    /* Error colors */
    --material-error-color: var(--error-color, #b00020);
    --material-error-text-color: var(--material-error-color);

    /* Background colors */
    --material-background-color: var(--light-theme-background-color, #fff);
    --material-secondary-background-color: var(--light-theme-secondary-background-color, #f5f5f5);
    --material-disabled-color: rgba(0, 0, 0, 0.26);

    /* Divider colors */
    --material-divider-color: rgba(0, 0, 0, 0.12);

    /* Undocumented internal properties (prefixed with three dashes) */

    /* Text field tweaks */
    --_material-text-field-input-line-background-color: initial;
    --_material-text-field-input-line-opacity: initial;
    --_material-text-field-input-line-hover-opacity: initial;
    --_material-text-field-focused-label-opacity: initial;

    /* Button tweaks */
    --_material-button-raised-background-color: initial;
    --_material-button-outline-color: initial;

    /* Grid tweaks */
    --_material-grid-row-hover-background-color: initial;

    /* Split layout tweaks */
    --_material-split-layout-splitter-background-color: initial;

    background-color: var(--material-background-color);
    color: var(--material-body-text-color);
  }

  [theme~="dark"] {
    /* Text colors */
    --material-body-text-color: var(--dark-theme-text-color, rgba(255, 255, 255, 1));
    --material-secondary-text-color: var(--dark-theme-secondary-color, rgba(255, 255, 255, 0.7));
    --material-disabled-text-color: var(--dark-theme-disabled-color, rgba(255, 255, 255, 0.5));

    /* Primary colors */
    --material-primary-color: var(--light-primary-color, #7e3ff2);
    --material-primary-text-color: #b794f6;

    /* Error colors */
    --material-error-color: var(--error-color, #de2839);
    --material-error-text-color: var(--material-error-color);

    /* Background colors */
    --material-background-color: var(--dark-theme-background-color, #303030);
    --material-secondary-background-color: var(--dark-theme-secondary-background-color, #3b3b3b);
    --material-disabled-color: rgba(255, 255, 255, 0.3);

    /* Divider colors */
    --material-divider-color: rgba(255, 255, 255, 0.12);

    /* Undocumented internal properties (prefixed with three dashes) */

    /* Text field tweaks */
    --_material-text-field-input-line-background-color: #fff;
    --_material-text-field-input-line-opacity: 0.7;
    --_material-text-field-input-line-hover-opacity: 1;
    --_material-text-field-focused-label-opacity: 1;

    /* Button tweaks */
    --_material-button-raised-background-color: rgba(255, 255, 255, 0.08);
    --_material-button-outline-color: rgba(255, 255, 255, 0.2);

    /* Grid tweaks */
    --_material-grid-row-hover-background-color: rgba(255, 255, 255, 0.08);
    --_material-grid-row-selected-overlay-opacity: 0.16;

    /* Split layout tweaks */
    --_material-split-layout-splitter-background-color: rgba(255, 255, 255, 0.8);

    background-color: var(--material-background-color);
    color: var(--material-body-text-color);
  }

  a {
    color: inherit;
  }
`;
registerStyles('', colorLight, {moduleId: 'material-color-light'});

export { colorLight };
const colorDark = css`

  :host,
  #host-fix {
    /* Text colors */
    --material-body-text-color: var(--dark-theme-text-color, rgba(255, 255, 255, 1));
    --material-secondary-text-color: var(--dark-theme-secondary-color, rgba(255, 255, 255, 0.7));
    --material-disabled-text-color: var(--dark-theme-disabled-color, rgba(255, 255, 255, 0.5));

    /* Primary colors */
    --material-primary-color: var(--light-primary-color, #7e3ff2);
    --material-primary-text-color: #b794f6;

    /* Error colors */
    --material-error-color: var(--error-color, #de2839);
    --material-error-text-color: var(--material-error-color);

    /* Background colors */
    --material-background-color: var(--dark-theme-background-color, #303030);
    --material-secondary-background-color: var(--dark-theme-secondary-background-color, #3b3b3b);
    --material-disabled-color: rgba(255, 255, 255, 0.3);

    /* Divider colors */
    --material-divider-color: rgba(255, 255, 255, 0.12);

    /* Undocumented internal properties (prefixed with three dashes) */

    /* Text field tweaks */
    --_material-text-field-input-line-background-color: #fff;
    --_material-text-field-input-line-opacity: 0.7;
    --_material-text-field-input-line-hover-opacity: 1;
    --_material-text-field-focused-label-opacity: 1;

    /* Button tweaks */
    --_material-button-raised-background-color: rgba(255, 255, 255, 0.08);
    --_material-button-outline-color: rgba(255, 255, 255, 0.2);

    /* Grid tweaks */
    --_material-grid-row-hover-background-color: rgba(255, 255, 255, 0.08);
    --_material-grid-row-selected-overlay-opacity: 0.16;

    /* Split layout tweaks */
    --_material-split-layout-splitter-background-color: rgba(255, 255, 255, 0.8);

    background-color: var(--material-background-color);
    color: var(--material-body-text-color);
  }
`;
registerStyles('', colorDark, {moduleId: 'material-color-dark'});

export { colorDark };
const colorBase = css`
:host {
  /* Text colors */
  --material-body-text-color: var(--light-theme-text-color, rgba(0, 0, 0, 0.87));
  --material-secondary-text-color: var(--light-theme-secondary-color, rgba(0, 0, 0, 0.54));
  --material-disabled-text-color: var(--light-theme-disabled-color, rgba(0, 0, 0, 0.38));

  /* Primary colors */
  --material-primary-color: var(--primary-color, #6200ee);
  --material-primary-contrast-color: var(--dark-theme-base-color, #fff);
  --material-primary-text-color: var(--material-primary-color);

  /* Error colors */
  --material-error-color: var(--error-color, #b00020);
  --material-error-text-color: var(--material-error-color);

  /* Background colors */
  --material-background-color: var(--light-theme-background-color, #fff);
  --material-secondary-background-color: var(--light-theme-secondary-background-color, #f5f5f5);
  --material-disabled-color: rgba(0, 0, 0, 0.26);

  /* Divider colors */
  --material-divider-color: rgba(0, 0, 0, 0.12);
}
`;
const $tpl = document.createElement('template');
$tpl.innerHTML = `<custom-style><style>${colorBase.toString().replace(':host', 'html')}</style></custom-style>`;
document.head.appendChild($tpl.content);

export { colorBase };
```
</details>

<details>
<summary>shadow.js</summary>

```js
import './version.js';
import '@polymer/polymer/lib/elements/custom-style.js';
import { css } from 'vaadin-themable-mixin/register-styles.js';
const shadow = css`
:host {
  /* from http://codepen.io/shyndman/pen/c5394ddf2e8b2a5c9185904b57421cdb */
  --material-shadow-elevation-2dp: 0 2px 2px 0 rgba(0, 0, 0, 0.14), 0 1px 5px 0 rgba(0, 0, 0, 0.12), 0 3px 1px -2px rgba(0, 0, 0, 0.2);
  --material-shadow-elevation-3dp: 0 3px 4px 0 rgba(0, 0, 0, 0.14), 0 1px 8px 0 rgba(0, 0, 0, 0.12), 0 3px 3px -2px rgba(0, 0, 0, 0.4);
  --material-shadow-elevation-4dp: 0 4px 5px 0 rgba(0, 0, 0, 0.14), 0 1px 10px 0 rgba(0, 0, 0, 0.12), 0 2px 4px -1px rgba(0, 0, 0, 0.4);
  --material-shadow-elevation-6dp: 0 6px 10px 0 rgba(0, 0, 0, 0.14), 0 1px 18px 0 rgba(0, 0, 0, 0.12), 0 3px 5px -1px rgba(0, 0, 0, 0.4);
  --material-shadow-elevation-8dp: 0 8px 10px 1px rgba(0, 0, 0, 0.14), 0 3px 14px 2px rgba(0, 0, 0, 0.12), 0 5px 5px -3px rgba(0, 0, 0, 0.4);
  --material-shadow-elevation-12dp: 0 12px 16px 1px rgba(0, 0, 0, 0.14), 0 4px 22px 3px rgba(0, 0, 0, 0.12), 0 6px 7px -4px rgba(0, 0, 0, 0.4);
  --material-shadow-elevation-16dp: 0 16px 24px 2px rgba(0, 0, 0, 0.14), 0 6px 30px 5px rgba(0, 0, 0, 0.12), 0 8px 10px -5px rgba(0, 0, 0, 0.4);
  --material-shadow-elevation-24dp: 0 24px 38px 3px rgba(0, 0, 0, 0.14), 0 9px 46px 8px rgba(0, 0, 0, 0.12), 0 11px 15px -7px rgba(0, 0, 0, 0.4);
}
`;
const $tpl = document.createElement('template');
$tpl.innerHTML = `<custom-style><style>${shadow.toString().replace(':host', 'html')}</style></custom-style>`;
document.head.appendChild($tpl.content);

export { shadow };
```
</details>

<details>
<summary>typography.js</summary>

```js
import './version.js';
import '@polymer/polymer/lib/elements/custom-style.js';
import { css, registerStyles } from 'vaadin-themable-mixin/register-styles.js';
const font = css`
:host {
  /* Font family */
  --material-font-family: 'Roboto', sans-serif;

  /* Font sizes */
  --material-h1-font-size: 6rem;
  --material-h2-font-size: 3.75rem;
  --material-h3-font-size: 3rem;
  --material-h4-font-size: 2.125rem;
  --material-h5-font-size: 1.5rem;
  --material-h6-font-size: 1.25rem;
  --material-body-font-size: 1rem;
  --material-small-font-size: 0.875rem;
  --material-button-font-size: 0.875rem;
  --material-caption-font-size: 0.75rem;

  /* Icon size */
  --material-icon-font-size: 20px;
}
`;
const $tpl = document.createElement('template');
$tpl.innerHTML = `<custom-style><style>${font.toString().replace(':host', 'html')}</style></custom-style>`;
document.head.appendChild($tpl.content);

export { font };
const typography = css`

  body {
    font-family: var(--material-font-family);
    font-size: var(--material-body-font-size);
    line-height: 1.4;
    -webkit-text-size-adjust: 100%;
    -webkit-font-smoothing: antialiased;
    -moz-osx-font-smoothing: grayscale;
  }

  /* Can’t combine with the above selector because that doesn’t work in browsers without native shadow dom */
  :host {
    font-family: var(--material-font-family);
    font-size: var(--material-body-font-size);
    line-height: 1.4;
    -webkit-text-size-adjust: 100%;
    -webkit-font-smoothing: antialiased;
    -moz-osx-font-smoothing: grayscale;
  }

  h1,
  h2,
  h3,
  h4,
  h5,
  h6 {
    color: inherit;
    line-height: 1.1;
    margin-top: 1.5em;
  }

  h1 {
    font-size: var(--material-h3-font-size);
    font-weight: 300;
    letter-spacing: -0.015em;
    margin-bottom: 1em;
    text-indent: -0.07em;
  }

  h2 {
    font-size: var(--material-h4-font-size);
    font-weight: 300;
    letter-spacing: -0.01em;
    margin-bottom: 0.75em;
    text-indent: -0.07em;
  }

  h3 {
    font-size: var(--material-h5-font-size);
    font-weight: 400;
    margin-bottom: 0.75em;
    text-indent: -0.05em;
  }

  h4 {
    font-size: var(--material-h6-font-size);
    font-weight: 400;
    letter-spacing: 0.01em;
    margin-bottom: 0.75em;
    text-indent: -0.05em;
  }

  h5 {
    font-size: var(--material-body-font-size);
    font-weight: 500;
    margin-bottom: 0.5em;
    text-indent: -0.025em;
  }

  h6 {
    font-size: var(--material-small-font-size);
    font-weight: 500;
    letter-spacing: 0.01em;
    margin-bottom: 0.25em;
    text-indent: -0.025em;
  }

  a,
  b,
  strong {
    font-weight: 500;
  }
`;
registerStyles('', typography, {moduleId: 'material-typography'});

export { typography };

/* Import Roboto from Google Fonts */
/*
  FIXME(polymer-modulizer): the above comments were extracted
  from HTML and may be out of place here. Review them and
  then delete this comment!
*/
if (!window.polymerSkipLoadingFontRoboto) {
  const font = 'https://fonts.googleapis.com/css?family=Roboto+Mono:400,700|Roboto:400,300,300italic,400italic,500,500italic,700,700italic';
  const link = document.createElement('link');
  link.rel = 'stylesheet';
  link.type = 'text/css';
  link.crossOrigin = 'anonymous';
  link.href = font;
  document.head.appendChild(link);
}
```
</details>

<details>
<summary>mixins/field-button.js</summary>

```js
import '../font-icons.js';
import { css, registerStyles } from 'vaadin-themable-mixin/register-styles.js';
const fieldButton = css`
  [part$="button"] {
    flex: none;
    width: 24px;
    height: 24px;
    padding: 4px;
    color: var(--material-secondary-text-color);
    font-size: var(--material-icon-font-size);
    line-height: 24px;
    text-align: center;
  }

  :host(:not([readonly])) [part$="button"] {
    cursor: pointer;
  }

  :host(:not([readonly])) [part$="button"]:hover {
    color: var(--material-text-color);
  }

  :host([disabled]) [part$="button"],
  :host([readonly]) [part$="button"] {
    color: var(--material-disabled-text-color);
  }

  :host([disabled]) [part="clear-button"] {
    display: none;
  }

  [part$="button"]::before {
    font-family: "material-icons";
  }
`;
registerStyles('', fieldButton, {moduleId: 'material-field-button'});

export { fieldButton };
```
</details>

<details>
<summary>mixins/menu-overlay.js</summary>

```js
import '../color.js';
import './overlay.js';
import { css, registerStyles } from 'vaadin-themable-mixin/register-styles.js';
const menuOverlay = css`
`;
registerStyles('', menuOverlay, {moduleId: 'material-menu-overlay', include: ['material-overlay']});

export { menuOverlay };
```
</details>

<details>
<summary>mixins/overlay.js</summary>

```js
import '../color.js';
import '../typography.js';
import '../shadow.js';
import { css, registerStyles } from 'vaadin-themable-mixin/register-styles.js';
const overlay = css`
  :host {
    top: 16px;
    right: 16px;
    /* TODO (@jouni): remove unnecessary multiplication after https://github.com/vaadin/vaadin-overlay/issues/90 is fixed */
    bottom: calc(1px * var(--vaadin-overlay-viewport-bottom) + 16px);
    left: 16px;
  }

  [part="overlay"] {
    background-color: var(--material-background-color);
    border-radius: 4px;
    box-shadow: var(--material-shadow-elevation-4dp);
    color: var(--material-body-text-color);
    font-family: var(--material-font-family);
    font-size: var(--material-body-font-size);
    font-weight: 400;
  }

  [part="content"] {
    padding: 8px 0;
  }

  [part="backdrop"] {
    opacity: 0.2;
    animation: 0.2s vaadin-overlay-backdrop-enter;
    will-change: opacity;
  }

  @keyframes vaadin-overlay-backdrop-enter {
    0% {
      opacity: 0;
    }
  }
`;
registerStyles('', overlay, {moduleId: 'material-overlay'});

export { overlay };
```
</details>

<details>
<summary>mixins/required-field.js</summary>

```js
import '../color.js';
import { css, registerStyles } from 'vaadin-themable-mixin/register-styles.js';
const requiredField = css`
  [part="label"] {
    display: block;
    position: absolute;
    top: 8px;
    font-size: 1em;
    line-height: 1;
    height: 20px;
    margin-bottom: -4px;
    white-space: nowrap;
    overflow-x: hidden;
    text-overflow: ellipsis;
    color: var(--material-secondary-text-color);
    transform-origin: 0 75%;
    transform: scale(0.75);
  }

  :host([required]) [part="label"]::after {
    content: " *";
    color: inherit;
  }

  :host([invalid]) [part="label"] {
    color: var(--material-error-text-color);
  }

  [part="error-message"] {
    font-size: .75em;
    line-height: 1;
    color: var(--material-error-text-color);
  }

  /* Margin that doesn’t reserve space when there’s no error message */
  [part="error-message"]:not(:empty)::before {
    content: "";
    display: block;
    height: 6px;
  }

  :host(:not([invalid])) [part="error-message"] {
    margin-top: 0;
    max-height: 0;
    overflow: hidden;
  }

  :host([invalid]) [part="error-message"] {
    animation: reveal 0.2s;
  }

  @keyframes reveal {
    0% {
      opacity: 0;
    }
  }

  /* RTL specific styles */
  :host([dir="rtl"]) [part="label"] {
    transform-origin: 100% 75%;
  }
`;
registerStyles('', requiredField, {moduleId: 'material-required-field'});

export { requiredField };
```
</details>